### PR TITLE
Adapt to libc fix

### DIFF
--- a/src/dylib.rs
+++ b/src/dylib.rs
@@ -24,7 +24,7 @@ impl Dylib {
 
     pub unsafe fn init(&self, path: &str) -> bool {
         let name = CString::new(path).unwrap();
-        let ptr = libc::dlopen(name.as_ptr(), libc::RTLD_LAZY);
+        let ptr = libc::dlopen(name.as_ptr() as *const i8, libc::RTLD_LAZY);
         if ptr.is_null() {
             return false
         }


### PR DESCRIPTION
As far as I can tell, libc changed their c_char type from u8, which was incorrect, to i8, which was correct. This was an inherently a breaking change. (See https://github.com/rust-lang/libc/issues/752)

Other than that, I don't think the behavior has changed. I'm pretty sure the only thing that needs to be done is to cast the pointer to the appropriate type.

This pull request solves https://github.com/badboy/rust-triangle-js/issues/1, and enabled my project (https://github.com/elidupree/time-steward) to compile with emscripten again.